### PR TITLE
Don't use PHP_EOL as a limiter for explode

### DIFF
--- a/src/josegonzalez/Dotenv/Loader.php
+++ b/src/josegonzalez/Dotenv/Loader.php
@@ -118,7 +118,7 @@ class Loader
             );
         }
 
-        $lines = explode(PHP_EOL, $fc);
+        $lines = preg_split('/\r\n|\r|\n/', $fc);
 
         $this->environment = array();
         foreach ($lines as $line) {


### PR DESCRIPTION
Nearly every editor (beside notepad) saves files with UNIX line endings (\r\n). As PHP_EOL defaults to \r\n on Windows, saving the file once in an editor of your choice means that splitting lines won't work.

Fixes #3
