### PR TITLE
Preserve existing zero-like variables

### DIFF
--- a/src/josegonzalez/Dotenv/Loader.php
+++ b/src/josegonzalez/Dotenv/Loader.php
@@ -237,7 +237,7 @@ class Loader
         $this->requireParse('apache_setenv');
         foreach ($this->environment as $key => $value) {
             $prefixedKey = $this->prefixed($key);
-            if (apache_getenv($prefixedKey) && !$overwrite) {
+            if (apache_getenv($prefixedKey) !== false && !$overwrite) {
                 if ($this->skip['apacheSetenv']) {
                     continue;
                 }
@@ -281,7 +281,7 @@ class Loader
         $this->requireParse('putenv');
         foreach ($this->environment as $key => $value) {
             $prefixedKey = $this->prefixed($key);
-            if (getenv($prefixedKey) && !$overwrite) {
+            if (getenv($prefixedKey) !== false && !$overwrite) {
                 if ($this->skip['putenv']) {
                     continue;
                 }
@@ -303,7 +303,7 @@ class Loader
         $this->requireParse('toEnv');
         foreach ($this->environment as $key => $value) {
             $prefixedKey = $this->prefixed($key);
-            if (isset($_ENV[$prefixedKey]) && !$overwrite) {
+            if (array_key_exists($prefixedKey, $_ENV) && !$overwrite) {
                 if ($this->skip['toEnv']) {
                     continue;
                 }
@@ -325,7 +325,7 @@ class Loader
         $this->requireParse('toServer');
         foreach ($this->environment as $key => $value) {
             $prefixedKey = $this->prefixed($key);
-            if (isset($_SERVER[$prefixedKey]) && !$overwrite) {
+            if (array_key_exists($prefixedKey, $_SERVER) && !$overwrite) {
                 if ($this->skip['toServer']) {
                     continue;
                 }

--- a/tests/josegonzalez/fixtures/zero_test_0.env
+++ b/tests/josegonzalez/fixtures/zero_test_0.env
@@ -1,0 +1,4 @@
+Z_NUMBER=0
+Z_BOOL=false
+Z_STRING=""
+Z_NULLABLE=null

--- a/tests/josegonzalez/fixtures/zero_test_1.env
+++ b/tests/josegonzalez/fixtures/zero_test_1.env
@@ -1,0 +1,4 @@
+Z_NUMBER=1
+Z_BOOL=true
+Z_STRING=foo_bar
+Z_NULLABLE="None null"


### PR DESCRIPTION
I expected that variables in subsequent loading never overwrite existing one. But zero-like values are overwritten.

1st load:

```
MUST_BE_ZERO=0
MUST_BE_NULL=null
```

2nd load (with skipExistings):

```
MUST_BE_ZERO=1
MUST_BE_NULL=1
```

Unexpected result:

```php
getenv('MUST_BE_ZERO') === "1"
$_ENV['MUST_BE_NULL'] === 1
```

I think that users want force disabling some option (enabled as default) in OS environment settings.

